### PR TITLE
don't try to render unsupported view models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /vendor
 /composer.lock
+.idea/

--- a/src/View/SmartyRenderer.php
+++ b/src/View/SmartyRenderer.php
@@ -109,6 +109,10 @@ class SmartyRenderer implements RendererInterface
         return $content;
     }
 
+    /**
+     * @param $nameOrModel
+     * @return bool
+     */
     public function canRender($nameOrModel)
     {
         if ($nameOrModel instanceof ModelInterface) {


### PR DESCRIPTION
If `JsonModel` and `ViewModel` not skipped in `SmartyStrategy` than in configured template_c/ directory 
creates compiled files for phtml view files, like

```
9cc9ae64dc86de5be49d0ab749b4633811e60a35.file.404.phtml.php
```

this pull fix this issue
